### PR TITLE
AALC redundancy transform process

### DIFF
--- a/meta-facebook/aalc-rpu/src/platform/plat_hwmon.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hwmon.c
@@ -333,9 +333,7 @@ bool rpu_remote_power_cycle_function(pump_reset_struct *data, uint8_t bit_val)
 void abnormal_pump_redundant_transform(uint32_t pump_sensor_num)
 {
 	uint32_t current_state = get_status_flag(STATUS_FLAG_PUMP_REDUNDANT);
-	printf("STATUS_FLAG_PUMP_REDUNDANT: %d\n", current_state);
 	if (get_status_flag(STATUS_FLAG_PUMP_REDUNDANT) != PUMP_REDUNDANT_DISABLE) {
-		printf("pump_sensor_num: %d\n", pump_sensor_num);
 		switch (pump_sensor_num) {
 		case SENSOR_NUM_PB_1_PUMP_TACH_RPM:
 			if (current_state == PUMP_REDUNDANT_MAX ||
@@ -363,8 +361,6 @@ void abnormal_pump_redundant_transform(uint32_t pump_sensor_num)
 		}
 	} else
 		LOG_ERR("transform failed due to disabled redundancy");
-
-	printf("STATUS_FLAG_PUMP_REDUNDANT_II: %d\n", get_status_flag(STATUS_FLAG_PUMP_REDUNDANT));
 }
 
 // pump redundant
@@ -403,7 +399,9 @@ void pump_redundant_enable(uint8_t onoff)
 		if (get_status_flag(STATUS_FLAG_PUMP_REDUNDANT) == PUMP_REDUNDANT_DISABLE)
 			k_timer_start(&pump_redundant_timer, K_NO_WAIT,
 				      K_MINUTES(pump_redundant_switch_time *
-						(pump_redundant_switch_time_type ? 1 : 1440)));
+						(pump_redundant_switch_time_type ?
+							 1 :
+							 1440))); // 7 *24 * 60 mins = 7 days
 	} else {
 		k_timer_stop(&pump_redundant_timer);
 	}

--- a/meta-facebook/aalc-rpu/src/platform/plat_hwmon.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_hwmon.h
@@ -60,6 +60,7 @@ bool pump_setting_set_pump_redundant(pump_reset_struct *data, uint8_t bit_val);
 bool modbus_pump_setting_unsupport_function(pump_reset_struct *data, uint8_t bit_val);
 bool set_all_pump_power(bool switch_val);
 bool rpu_remote_power_cycle_function(pump_reset_struct *data, uint8_t bit_val);
+void abnormal_pump_redundant_transform(uint32_t pump_sensor_num);
 uint8_t get_pump_redundant_switch_time();
 void set_pump_redundant_switch_time(uint8_t time);
 void set_pump_redundant_switch_time_type(uint8_t type);

--- a/meta-facebook/aalc-rpu/src/platform/plat_pwm.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_pwm.c
@@ -36,6 +36,10 @@ static uint8_t fan_group_duty_cache[PWM_GROUP_E_MAX];
 static uint8_t fan_duty_cache[PWM_DEVICE_E_MAX];
 static uint8_t manual_pwm_flag[MANUAL_PWM_E_MAX];
 static uint8_t manual_pwm_cache[MANUAL_PWM_E_MAX];
+static uint8_t redundant_dev_pre = PWM_DEVICE_E_MAX;
+static enum REDUNDANCY_TRANSFORM_E redundant_phase = REDUNDANCY_TRANSFORM_DISABLE;
+static uint8_t redundant_step1_count = REDUNDANT_STEP1_RETRY;
+static uint8_t redundant_step2_count = REDUNDANT_STEP2_RETRY;
 
 struct nct_dev_info {
 	enum PWM_DEVICE_E dev;
@@ -250,10 +254,13 @@ static uint8_t ctl_pwm_dev(uint8_t index_start, uint8_t index_end, uint8_t duty)
 
 	uint8_t ret = 0;
 	uint32_t redundant_mode = get_status_flag(STATUS_FLAG_PUMP_REDUNDANT);
-	uint8_t redundant_dev = (redundant_mode == PUMP_REDUNDANT_12) ? PWM_DEVICE_E_PB_PUMB_3 :
-				(redundant_mode == PUMP_REDUNDANT_13) ? PWM_DEVICE_E_PB_PUMB_2 :
-				(redundant_mode == PUMP_REDUNDANT_23) ? PWM_DEVICE_E_PB_PUMB_1 :
-									PWM_DEVICE_E_MAX;
+	uint8_t redundant_dev = (redundant_mode == PUMP_REDUNDANT_12) ?
+					PWM_DEVICE_E_PB_PUMB_3 :
+					(redundant_mode == PUMP_REDUNDANT_13) ?
+					PWM_DEVICE_E_PB_PUMB_2 :
+					(redundant_mode == PUMP_REDUNDANT_23) ?
+					PWM_DEVICE_E_PB_PUMB_1 :
+					PWM_DEVICE_E_MAX;
 
 	for (uint8_t i = index_start; i <= index_end; i++) {
 		if (i == redundant_dev) {
@@ -273,6 +280,97 @@ static uint8_t ctl_pwm_dev(uint8_t index_start, uint8_t index_end, uint8_t duty)
 	}
 
 	return ret;
+}
+
+static uint8_t ctl_pwm_pump(uint8_t duty)
+{
+	if (duty > MAX_FAN_DUTY_VALUE) {
+		LOG_ERR("Invalid PWM duty %d", duty);
+		return 1;
+	}
+
+	uint8_t ret = 0;
+	uint32_t redundant_mode = get_status_flag(STATUS_FLAG_PUMP_REDUNDANT);
+	uint8_t redundant_dev = (redundant_mode == PUMP_REDUNDANT_12) ?
+					PWM_DEVICE_E_PB_PUMB_3 :
+					(redundant_mode == PUMP_REDUNDANT_13) ?
+					PWM_DEVICE_E_PB_PUMB_2 :
+					(redundant_mode == PUMP_REDUNDANT_23) ?
+					PWM_DEVICE_E_PB_PUMB_1 :
+					PWM_DEVICE_E_MAX;
+	printf("redundant_dev: %d\n", redundant_dev);
+	printf("redundant_dev_pre: %d\n", redundant_dev_pre);
+	printf("pump1_duty: %d\n", get_pwm_cache(PWM_DEVICE_E_PB_PUMB_1));
+	printf("pump2_duty: %d\n", get_pwm_cache(PWM_DEVICE_E_PB_PUMB_2));
+	printf("pump3_duty: %d\n", get_pwm_cache(PWM_DEVICE_E_PB_PUMB_3));
+	if (redundant_dev != PWM_DEVICE_E_MAX && redundant_dev_pre != redundant_dev) {
+		switch (redundant_phase) {
+		case REDUNDANCY_TRANSFORM_DISABLE:
+			printf("step1-1\n");
+			for (uint8_t i = PWM_DEVICE_E_PB_PUMB_1; i <= PWM_DEVICE_E_PB_PUMB_3; i++) {
+				if (i == redundant_dev_pre)
+					ret |= (plat_pwm_ctrl(i, 0) ? 1 : 0);
+				else
+					ret |= (plat_pwm_ctrl(i, 100) ? 1 : 0);
+			}
+			printf("step1-2\n");
+			redundant_step1_count--;
+			if (redundant_step1_count == 0) {
+				redundant_phase = REDUNDANCY_TRANSFORM_STEP_1;
+				redundant_step1_count = REDUNDANT_STEP1_RETRY;
+			}
+			printf("step1-3\n");
+			return ret;
+		case REDUNDANCY_TRANSFORM_STEP_1:
+			printf("step2-1\n");
+			for (uint8_t i = PWM_DEVICE_E_PB_PUMB_1; i <= PWM_DEVICE_E_PB_PUMB_3; i++) {
+				if (i == redundant_dev)
+					ret |= (plat_pwm_ctrl(i, 0) ? 1 : 0);
+				else
+					ret |= (plat_pwm_ctrl(i, 100) ? 1 : 0);
+			}
+			printf("step2-2\n");
+			redundant_step2_count--;
+			if (redundant_step2_count == 0) {
+				redundant_phase = REDUNDANCY_TRANSFORM_STEP_2;
+				redundant_step2_count = REDUNDANT_STEP2_RETRY;
+			}
+			printf("step2-3\n");
+			return ret;
+		case REDUNDANCY_TRANSFORM_STEP_2:
+			redundant_dev_pre = redundant_dev;
+			printf("step3-1\n");
+			break;
+		}
+	} else {
+		redundant_phase = REDUNDANCY_TRANSFORM_DISABLE;
+		if (redundant_dev == PWM_DEVICE_E_MAX)
+			redundant_dev_pre = PWM_DEVICE_E_MAX;
+		printf("disable-redundant_dev: %d\n", redundant_dev);
+		printf("disable-redundant_dev_pre: %d\n", redundant_dev_pre);
+		printf("step-disable\n");
+	}
+
+	for (uint8_t i = PWM_DEVICE_E_PB_PUMB_1; i <= PWM_DEVICE_E_PB_PUMB_3; i++) {
+		if (i == redundant_dev)
+			ret |= (plat_pwm_ctrl(i, 0) ? 1 : 0);
+		else
+			ret |= (plat_pwm_ctrl(i, duty) ? 1 : 0);
+	}
+	printf("step-end\n");
+	return ret;
+}
+
+uint8_t get_redundant_transform_phase()
+{
+	return redundant_phase;
+}
+
+void set_redundant_transform_phase(uint8_t redundant_transform_phase)
+{
+	redundant_phase = redundant_transform_phase;
+	if (redundant_transform_phase == REDUNDANCY_TRANSFORM_DISABLE)
+		redundant_dev_pre = PWM_DEVICE_E_MAX;
 }
 
 uint8_t ctl_all_pwm_dev(uint8_t duty)
@@ -296,7 +394,7 @@ uint8_t set_pwm_group(uint8_t group, uint8_t duty)
 			ret = 0;
 		break;
 	case PWM_GROUP_E_PUMP:
-		if (!ctl_pwm_dev(PWM_DEVICE_E_PB_PUMB_1, PWM_DEVICE_E_PB_PUMB_3, duty))
+		if (!ctl_pwm_pump(duty))
 			ret = 0;
 		break;
 	case PWM_GROUP_E_RPU_FAN:
@@ -326,14 +424,19 @@ uint8_t get_pwm_cache(uint8_t idx)
 
 uint8_t manual_pwm_idx_to_pwm_idx(uint8_t idx)
 {
-	return (idx == MANUAL_PWM_E_PUMP_1)	 ? PWM_DEVICE_E_PB_PUMB_1 :
-	       (idx == MANUAL_PWM_E_PUMP_2)	 ? PWM_DEVICE_E_PB_PUMB_2 :
-	       (idx == MANUAL_PWM_E_PUMP_3)	 ? PWM_DEVICE_E_PB_PUMB_3 :
-	       (idx == MANUAL_PWM_E_PUMP_FAN_1)	 ? PWM_DEVICE_E_PB_PUMB_FAN_1 :
-	       (idx == MANUAL_PWM_E_PUMP_FAN_2)	 ? PWM_DEVICE_E_PB_PUMB_FAN_2 :
-	       (idx == MANUAL_PWM_E_PUMP_FAN_3)	 ? PWM_DEVICE_E_PB_PUMB_FAN_3 :
-	       (idx == MANUAL_PWM_E_RPU_PCB_FAN) ? PWM_DEVICE_E_BB_FAN :
-						   PWM_DEVICE_E_MAX;
+	return (idx == MANUAL_PWM_E_PUMP_1) ?
+		       PWM_DEVICE_E_PB_PUMB_1 :
+		       (idx == MANUAL_PWM_E_PUMP_2) ?
+		       PWM_DEVICE_E_PB_PUMB_2 :
+		       (idx == MANUAL_PWM_E_PUMP_3) ?
+		       PWM_DEVICE_E_PB_PUMB_3 :
+		       (idx == MANUAL_PWM_E_PUMP_FAN_1) ?
+		       PWM_DEVICE_E_PB_PUMB_FAN_1 :
+		       (idx == MANUAL_PWM_E_PUMP_FAN_2) ?
+		       PWM_DEVICE_E_PB_PUMB_FAN_2 :
+		       (idx == MANUAL_PWM_E_PUMP_FAN_3) ?
+		       PWM_DEVICE_E_PB_PUMB_FAN_3 :
+		       (idx == MANUAL_PWM_E_RPU_PCB_FAN) ? PWM_DEVICE_E_BB_FAN : PWM_DEVICE_E_MAX;
 }
 
 uint8_t get_manual_pwm_flag(uint8_t idx)

--- a/meta-facebook/aalc-rpu/src/platform/plat_pwm.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_pwm.c
@@ -298,57 +298,42 @@ static uint8_t ctl_pwm_pump(uint8_t duty)
 					(redundant_mode == PUMP_REDUNDANT_23) ?
 					PWM_DEVICE_E_PB_PUMB_1 :
 					PWM_DEVICE_E_MAX;
-	printf("redundant_dev: %d\n", redundant_dev);
-	printf("redundant_dev_pre: %d\n", redundant_dev_pre);
-	printf("pump1_duty: %d\n", get_pwm_cache(PWM_DEVICE_E_PB_PUMB_1));
-	printf("pump2_duty: %d\n", get_pwm_cache(PWM_DEVICE_E_PB_PUMB_2));
-	printf("pump3_duty: %d\n", get_pwm_cache(PWM_DEVICE_E_PB_PUMB_3));
 	if (redundant_dev != PWM_DEVICE_E_MAX && redundant_dev_pre != redundant_dev) {
 		switch (redundant_phase) {
 		case REDUNDANCY_TRANSFORM_DISABLE:
-			printf("step1-1\n");
 			for (uint8_t i = PWM_DEVICE_E_PB_PUMB_1; i <= PWM_DEVICE_E_PB_PUMB_3; i++) {
 				if (i == redundant_dev_pre)
 					ret |= (plat_pwm_ctrl(i, 0) ? 1 : 0);
 				else
 					ret |= (plat_pwm_ctrl(i, 100) ? 1 : 0);
 			}
-			printf("step1-2\n");
 			redundant_step1_count--;
 			if (redundant_step1_count == 0) {
 				redundant_phase = REDUNDANCY_TRANSFORM_STEP_1;
 				redundant_step1_count = REDUNDANT_STEP1_RETRY;
 			}
-			printf("step1-3\n");
 			return ret;
 		case REDUNDANCY_TRANSFORM_STEP_1:
-			printf("step2-1\n");
 			for (uint8_t i = PWM_DEVICE_E_PB_PUMB_1; i <= PWM_DEVICE_E_PB_PUMB_3; i++) {
 				if (i == redundant_dev)
 					ret |= (plat_pwm_ctrl(i, 0) ? 1 : 0);
 				else
 					ret |= (plat_pwm_ctrl(i, 100) ? 1 : 0);
 			}
-			printf("step2-2\n");
 			redundant_step2_count--;
 			if (redundant_step2_count == 0) {
 				redundant_phase = REDUNDANCY_TRANSFORM_STEP_2;
 				redundant_step2_count = REDUNDANT_STEP2_RETRY;
 			}
-			printf("step2-3\n");
 			return ret;
 		case REDUNDANCY_TRANSFORM_STEP_2:
 			redundant_dev_pre = redundant_dev;
-			printf("step3-1\n");
 			break;
 		}
 	} else {
 		redundant_phase = REDUNDANCY_TRANSFORM_DISABLE;
 		if (redundant_dev == PWM_DEVICE_E_MAX)
 			redundant_dev_pre = PWM_DEVICE_E_MAX;
-		printf("disable-redundant_dev: %d\n", redundant_dev);
-		printf("disable-redundant_dev_pre: %d\n", redundant_dev_pre);
-		printf("step-disable\n");
 	}
 
 	for (uint8_t i = PWM_DEVICE_E_PB_PUMB_1; i <= PWM_DEVICE_E_PB_PUMB_3; i++) {
@@ -357,7 +342,6 @@ static uint8_t ctl_pwm_pump(uint8_t duty)
 		else
 			ret |= (plat_pwm_ctrl(i, duty) ? 1 : 0);
 	}
-	printf("step-end\n");
 	return ret;
 }
 

--- a/meta-facebook/aalc-rpu/src/platform/plat_pwm.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_pwm.h
@@ -16,6 +16,10 @@
 
 #define PWM_PORT0 0
 
+#define REDUNDANT_STEP1_RETRY                                                                      \
+	2 /*Current interval in zone_table is 5s. DISABLE-> STEP1 spent 5*2 s*/
+#define REDUNDANT_STEP2_RETRY 2 /*Current interval in zone_table is 5s. STEP1-> STEP2 spent 5*2 s*/
+
 enum PWM_DEVICE_E {
 	PWM_DEVICE_E_FB_FAN_1 = 0,
 	PWM_DEVICE_E_FB_FAN_2,
@@ -64,9 +68,17 @@ enum MANUAL_PWM_E {
 	MANUAL_PWM_E_MAX,
 };
 
+enum REDUNDANCY_TRANSFORM_E {
+	REDUNDANCY_TRANSFORM_DISABLE = 0,
+	REDUNDANCY_TRANSFORM_STEP_1,
+	REDUNDANCY_TRANSFORM_STEP_2,
+};
+
 void init_pwm_dev(void);
 int ast_pwm_set(int duty);
 uint8_t plat_pwm_ctrl(enum PWM_DEVICE_E dev, uint8_t duty);
+uint8_t get_redundant_transform_phase();
+void set_redundant_transform_phase(uint8_t redundant_transform_phase);
 uint8_t ctl_all_pwm_dev(uint8_t duty);
 uint8_t set_pwm_group(uint8_t group, uint8_t duty);
 uint8_t get_pwm_group_cache(uint8_t group);

--- a/meta-facebook/aalc-rpu/src/platform/plat_pwm.h
+++ b/meta-facebook/aalc-rpu/src/platform/plat_pwm.h
@@ -18,7 +18,7 @@
 
 #define REDUNDANT_STEP1_RETRY                                                                      \
 	2 /*Current interval in zone_table is 5s. DISABLE-> STEP1 spent 5*2 s*/
-#define REDUNDANT_STEP2_RETRY 2 /*Current interval in zone_table is 5s. STEP1-> STEP2 spent 5*2 s*/
+#define REDUNDANT_STEP2_RETRY 12 /*Current interval in zone_table is 5s. STEP1-> STEP2 spent 5*2 s*/
 
 enum PWM_DEVICE_E {
 	PWM_DEVICE_E_FB_FAN_1 = 0,

--- a/meta-facebook/aalc-rpu/src/platform/plat_status.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_status.c
@@ -88,23 +88,32 @@ uint16_t get_sensor_status_for_modbus_cmd(uint8_t status)
 		WRITE_BIT(val, 1, (get_threshold_status(SENSOR_NUM_MB_FAN2_TACH_RPM)) ? 1 : 0);
 		break;
 	case RPU_PUMP1_STATUS:
-		val = (get_threshold_status(SENSOR_NUM_PB_1_PUMP_TACH_RPM)) ?
+		val = (get_threshold_status(SENSOR_NUM_PB_1_PUMP_TACH_RPM)) ==
+				      THRESHOLD_STATUS_NOT_ACCESS ?
+			      PUMP_STATUS_DISABLE :
+			      (get_threshold_status(SENSOR_NUM_PB_1_PUMP_TACH_RPM)) ?
 			      PUMP_STATUS_ABNORMAL :
-		      (get_status_flag(STATUS_FLAG_PUMP_REDUNDANT) == PUMP_REDUNDANT_23) ?
+			      (get_status_flag(STATUS_FLAG_PUMP_REDUNDANT) == PUMP_REDUNDANT_23) ?
 			      PUMP_STATUS_REDAUNDANT :
 			      PUMP_STATUS_ENABLE;
 		break;
 	case RPU_PUMP2_STATUS:
-		val = (get_threshold_status(SENSOR_NUM_PB_2_PUMP_TACH_RPM)) ?
+		val = (get_threshold_status(SENSOR_NUM_PB_2_PUMP_TACH_RPM)) ==
+				      THRESHOLD_STATUS_NOT_ACCESS ?
+			      PUMP_STATUS_DISABLE :
+			      (get_threshold_status(SENSOR_NUM_PB_2_PUMP_TACH_RPM)) ?
 			      PUMP_STATUS_ABNORMAL :
-		      (get_status_flag(STATUS_FLAG_PUMP_REDUNDANT) == PUMP_REDUNDANT_13) ?
+			      (get_status_flag(STATUS_FLAG_PUMP_REDUNDANT) == PUMP_REDUNDANT_13) ?
 			      PUMP_STATUS_REDAUNDANT :
 			      PUMP_STATUS_ENABLE;
 		break;
 	case RPU_PUMP3_STATUS:
-		val = (get_threshold_status(SENSOR_NUM_PB_3_PUMP_TACH_RPM)) ?
+		val = (get_threshold_status(SENSOR_NUM_PB_3_PUMP_TACH_RPM)) ==
+				      THRESHOLD_STATUS_NOT_ACCESS ?
+			      PUMP_STATUS_DISABLE :
+			      (get_threshold_status(SENSOR_NUM_PB_3_PUMP_TACH_RPM)) ?
 			      PUMP_STATUS_ABNORMAL :
-		      (get_status_flag(STATUS_FLAG_PUMP_REDUNDANT) == PUMP_REDUNDANT_12) ?
+			      (get_status_flag(STATUS_FLAG_PUMP_REDUNDANT) == PUMP_REDUNDANT_12) ?
 			      PUMP_STATUS_REDAUNDANT :
 			      PUMP_STATUS_ENABLE;
 		break;

--- a/meta-facebook/aalc-rpu/src/platform/plat_threshold.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_threshold.c
@@ -140,7 +140,7 @@ bool pump_fail_check()
 {
 	uint8_t fail_num = 0;
 	for (uint8_t i = 0; i < ARRAY_SIZE(pump_sensor_array); i++) {
-		if (get_threshold_status(pump_sensor_array[i]))
+		if (get_threshold_status(pump_sensor_array[i]) == THRESHOLD_STATUS_LCR)
 			fail_num++;
 	}
 

--- a/meta-facebook/aalc-rpu/src/platform/plat_threshold.c
+++ b/meta-facebook/aalc-rpu/src/platform/plat_threshold.c
@@ -547,9 +547,9 @@ void abnormal_temp_do(uint32_t sensor_num, uint32_t status)
 {
 	uint8_t failure_status = (sensor_num == SENSOR_NUM_BPB_RPU_COOLANT_INLET_TEMP_C) ?
 					 PUMP_FAIL_ABNORMAL_COOLANT_INLET_TEMP :
-				 (sensor_num == SENSOR_NUM_BPB_RPU_COOLANT_OUTLET_TEMP_C) ?
+					 (sensor_num == SENSOR_NUM_BPB_RPU_COOLANT_OUTLET_TEMP_C) ?
 					 PUMP_FAIL_ABNORMAL_COOLANT_OUTLET_TEMP :
-				 (sensor_num == SENSOR_NUM_MB_RPU_AIR_INLET_TEMP_C) ?
+					 (sensor_num == SENSOR_NUM_MB_RPU_AIR_INLET_TEMP_C) ?
 					 PUMP_FAIL_ABNORMAL_AIR_INLET_TEMP :
 					 0xFF;
 
@@ -760,22 +760,29 @@ void pump_failure_do(uint32_t thres_tbl_idx, uint32_t status)
 	sensor_threshold const *thres_p = &threshold_tbl[thres_tbl_idx];
 	uint32_t sensor_num = thres_p->sensor_num;
 
-	uint8_t pump_ucr = (sensor_num == SENSOR_NUM_PB_1_PUMP_TACH_RPM) ? PUMP_FAIL_PUMP1_UCR :
-			   (sensor_num == SENSOR_NUM_PB_2_PUMP_TACH_RPM) ? PUMP_FAIL_PUMP2_UCR :
-			   (sensor_num == SENSOR_NUM_PB_3_PUMP_TACH_RPM) ? PUMP_FAIL_PUMP3_UCR :
-									   FAILURE_STATUS_MAX;
+	uint8_t pump_ucr = (sensor_num == SENSOR_NUM_PB_1_PUMP_TACH_RPM) ?
+				   PUMP_FAIL_PUMP1_UCR :
+				   (sensor_num == SENSOR_NUM_PB_2_PUMP_TACH_RPM) ?
+				   PUMP_FAIL_PUMP2_UCR :
+				   (sensor_num == SENSOR_NUM_PB_3_PUMP_TACH_RPM) ?
+				   PUMP_FAIL_PUMP3_UCR :
+				   FAILURE_STATUS_MAX;
 
-	uint8_t sensor_num_pump_ucr =
-		(sensor_num == SENSOR_NUM_PB_1_PUMP_TACH_RPM) ? SENSOR_NUM_PB_1_PUMP_TACH_RPM_UCR :
-		(sensor_num == SENSOR_NUM_PB_2_PUMP_TACH_RPM) ? SENSOR_NUM_PB_2_PUMP_TACH_RPM_UCR :
-		(sensor_num == SENSOR_NUM_PB_3_PUMP_TACH_RPM) ? SENSOR_NUM_PB_3_PUMP_TACH_RPM_UCR :
-								0xFF;
+	uint8_t sensor_num_pump_ucr = (sensor_num == SENSOR_NUM_PB_1_PUMP_TACH_RPM) ?
+					      SENSOR_NUM_PB_1_PUMP_TACH_RPM_UCR :
+					      (sensor_num == SENSOR_NUM_PB_2_PUMP_TACH_RPM) ?
+					      SENSOR_NUM_PB_2_PUMP_TACH_RPM_UCR :
+					      (sensor_num == SENSOR_NUM_PB_3_PUMP_TACH_RPM) ?
+					      SENSOR_NUM_PB_3_PUMP_TACH_RPM_UCR :
+					      0xFF;
 
 	switch (status) {
 	case THRESHOLD_STATUS_LCR:
 		error_log_event(sensor_num, IS_ABNORMAL_VAL);
 		if (pump_fail_check())
 			set_status_flag(STATUS_FLAG_FAILURE, PUMP_FAIL_TWO_PUMP_LCR, 1);
+		else
+			abnormal_pump_redundant_transform(sensor_num);
 		break;
 	case THRESHOLD_STATUS_UCR:
 		set_status_flag(STATUS_FLAG_FAILURE, pump_ucr, 1);


### PR DESCRIPTION
1. add the process for transforming redundancy
2. abnormal pump status triggers redundancy
3. redundancy shell cmd support min unit: minute
4. pump status is disabled when not access 